### PR TITLE
feat: Add automatic plugin update checking and download

### DIFF
--- a/RocketMax/RocketMax.cpp
+++ b/RocketMax/RocketMax.cpp
@@ -622,23 +622,57 @@ void RocketMax::processOfflineQueue()
 
 // ============ AUTO-UPDATE ============
 
-std::string RocketMax::getPluginPath()
+std::filesystem::path RocketMax::getPluginsFolder()
 {
-    // Get the plugins folder path from BakkesMod
-    std::string dataFolder = gameWrapper->GetDataFolder().string();
-    // Navigate from data folder to plugins folder
-    // Data folder is typically: %APPDATA%/bakkesmod/bakkesmod/data
-    // Plugins folder is: %APPDATA%/bakkesmod/bakkesmod/plugins
-    size_t pos = dataFolder.rfind("data");
-    if (pos != std::string::npos) {
-        return dataFolder.substr(0, pos) + "plugins/RocketMax.dll";
-    }
-    return "";
+    // Use std::filesystem to safely navigate from data folder to plugins folder
+    // Data folder: %APPDATA%/bakkesmod/bakkesmod/data
+    // Plugins folder: %APPDATA%/bakkesmod/bakkesmod/plugins
+    std::filesystem::path dataFolder = gameWrapper->GetDataFolder();
+    std::filesystem::path bakkesmodFolder = dataFolder.parent_path();  // Go up from "data"
+    return bakkesmodFolder / "plugins";
 }
 
-std::string RocketMax::getUpdateFilePath()
+std::filesystem::path RocketMax::getUpdateScriptPath()
 {
-    return gameWrapper->GetDataFolder().string() + "/RocketMax_update.dll";
+    return gameWrapper->GetDataFolder() / "rocketmax_update.ps1";
+}
+
+std::string RocketMax::extractJsonValue(const std::string& json, const std::string& key)
+{
+    // Simple JSON value extractor for string values
+    // Looks for: "key": "value" or "key":"value"
+    std::string searchKey = "\"" + key + "\"";
+    size_t keyPos = json.find(searchKey);
+    if (keyPos == std::string::npos) {
+        return "";
+    }
+
+    // Find the colon after the key
+    size_t colonPos = json.find(":", keyPos + searchKey.length());
+    if (colonPos == std::string::npos) {
+        return "";
+    }
+
+    // Skip whitespace and find opening quote
+    size_t quoteStart = json.find("\"", colonPos + 1);
+    if (quoteStart == std::string::npos) {
+        return "";
+    }
+
+    // Find closing quote (handle escaped quotes)
+    size_t quoteEnd = quoteStart + 1;
+    while (quoteEnd < json.length()) {
+        if (json[quoteEnd] == '\"' && json[quoteEnd - 1] != '\\') {
+            break;
+        }
+        quoteEnd++;
+    }
+
+    if (quoteEnd >= json.length()) {
+        return "";
+    }
+
+    return json.substr(quoteStart + 1, quoteEnd - quoteStart - 1);
 }
 
 bool RocketMax::parseVersionString(const std::string& version, int& major, int& minor, int& patch)
@@ -647,6 +681,12 @@ bool RocketMax::parseVersionString(const std::string& version, int& major, int& 
     std::string ver = version;
     if (!ver.empty() && (ver[0] == 'v' || ver[0] == 'V')) {
         ver = ver.substr(1);
+    }
+
+    // Remove any suffix like "-beta", "-rc1", etc.
+    size_t dashPos = ver.find('-');
+    if (dashPos != std::string::npos) {
+        ver = ver.substr(0, dashPos);
     }
 
     int parsed = sscanf(ver.c_str(), "%d.%d.%d", &major, &minor, &patch);
@@ -675,23 +715,22 @@ bool RocketMax::isNewerVersion(const std::string& remoteVersion)
 
 void RocketMax::checkForUpdates()
 {
-    if (update_checking) {
+    if (update_checking.load()) {
         LOG("[RocketMax] [Update] Already checking for updates...");
         return;
     }
 
-    update_checking = true;
+    update_checking.store(true);
     update_error = "";
     LOG("[RocketMax] [Update] Checking for updates...");
 
     CurlRequest req;
     req.url = GITHUB_API_RELEASES;
-    // Use empty body for GET request - SendCurlJsonRequest handles JSON response
     req.body = "";
 
     HttpWrapper::SendCurlJsonRequest(req, [this](int code, std::string result)
     {
-        update_checking = false;
+        update_checking.store(false);
 
         if (code != 200) {
             LOG("[RocketMax] [Update] Failed to check for updates. HTTP code: " + std::to_string(code));
@@ -701,41 +740,30 @@ void RocketMax::checkForUpdates()
 
         LOG("[RocketMax] [Update] Received response from GitHub API");
 
-        // Simple JSON parsing for tag_name and browser_download_url
-        // Looking for: "tag_name": "v1.2.3"
-        std::string tagKey = "\"tag_name\"";
-        size_t tagPos = result.find(tagKey);
-        if (tagPos == std::string::npos) {
+        // Extract tag_name using helper function
+        latest_version = extractJsonValue(result, "tag_name");
+        if (latest_version.empty()) {
             LOG("[RocketMax] [Update] Could not find tag_name in response");
             update_error = "Format de reponse invalide";
             return;
         }
-
-        // Find the value after tag_name
-        size_t colonPos = result.find(":", tagPos);
-        size_t quoteStart = result.find("\"", colonPos + 1);
-        size_t quoteEnd = result.find("\"", quoteStart + 1);
-        if (quoteStart == std::string::npos || quoteEnd == std::string::npos) {
-            update_error = "Erreur de parsing version";
-            return;
-        }
-
-        latest_version = result.substr(quoteStart + 1, quoteEnd - quoteStart - 1);
         LOG("[RocketMax] [Update] Latest version: " + latest_version);
 
-        // Find download URL for RocketMax.dll
+        // Find download URL for RocketMax.dll in assets array
+        // We need to find the browser_download_url that contains "RocketMax.dll"
         std::string dllName = "RocketMax.dll";
         size_t dllPos = result.find(dllName);
         if (dllPos != std::string::npos) {
-            // Look backwards for browser_download_url
+            // Look backwards for browser_download_url (it's in the same asset object)
             std::string urlKey = "\"browser_download_url\"";
             size_t urlKeyPos = result.rfind(urlKey, dllPos);
             if (urlKeyPos != std::string::npos) {
-                size_t urlColonPos = result.find(":", urlKeyPos + urlKey.length());
-                size_t urlQuoteStart = result.find("\"", urlColonPos + 1);
-                size_t urlQuoteEnd = result.find("\"", urlQuoteStart + 1);
-                if (urlQuoteStart != std::string::npos && urlQuoteEnd != std::string::npos) {
-                    update_download_url = result.substr(urlQuoteStart + 1, urlQuoteEnd - urlQuoteStart - 1);
+                // Extract the URL value
+                size_t colonPos = result.find(":", urlKeyPos + urlKey.length());
+                size_t quoteStart = result.find("\"", colonPos + 1);
+                size_t quoteEnd = result.find("\"", quoteStart + 1);
+                if (quoteStart != std::string::npos && quoteEnd != std::string::npos) {
+                    update_download_url = result.substr(quoteStart + 1, quoteEnd - quoteStart - 1);
                     LOG("[RocketMax] [Update] Download URL: " + update_download_url);
                 }
             }
@@ -743,7 +771,7 @@ void RocketMax::checkForUpdates()
 
         // Check if this is a newer version
         if (isNewerVersion(latest_version)) {
-            update_available = true;
+            update_available.store(true);
             LOG("[RocketMax] [Update] New version available: " + latest_version);
 
             gameWrapper->Execute([this](GameWrapper* gw) {
@@ -754,13 +782,13 @@ void RocketMax::checkForUpdates()
             });
         }
         else {
-            update_available = false;
+            update_available.store(false);
             LOG("[RocketMax] [Update] Already on latest version");
         }
     });
 }
 
-void RocketMax::downloadUpdate()
+void RocketMax::launchUpdateScript()
 {
     if (update_download_url.empty()) {
         update_error = "URL de telechargement non disponible";
@@ -768,76 +796,106 @@ void RocketMax::downloadUpdate()
         return;
     }
 
-    if (update_downloading) {
-        LOG("[RocketMax] [Update] Already downloading...");
+    update_error = "";
+    LOG("[RocketMax] [Update] Creating update script...");
+
+    // Get paths
+    std::filesystem::path pluginsFolder = getPluginsFolder();
+    std::filesystem::path pluginPath = pluginsFolder / "RocketMax.dll";
+    std::filesystem::path scriptPath = getUpdateScriptPath();
+
+    // Create PowerShell script that will:
+    // 1. Download the DLL from GitHub
+    // 2. Verify the download (check file size > 100KB for a valid DLL)
+    // 3. Replace the old plugin
+    // 4. Clean up
+    std::ofstream scriptFile(scriptPath);
+    if (!scriptFile.is_open()) {
+        update_error = "Impossible de creer le script";
+        LOG("[RocketMax] [Update] Could not create update script: " + scriptPath.string());
         return;
     }
 
-    update_downloading = true;
-    update_error = "";
-    LOG("[RocketMax] [Update] Starting download from: " + update_download_url);
+    scriptFile << "# RocketMax Auto-Update Script\n";
+    scriptFile << "# Generated by RocketMax Plugin v" << plugin_version << "\n";
+    scriptFile << "$ErrorActionPreference = 'Stop'\n\n";
+
+    scriptFile << "$downloadUrl = '" << update_download_url << "'\n";
+    scriptFile << "$pluginPath = '" << pluginPath.string() << "'\n";
+    scriptFile << "$tempPath = '" << (pluginsFolder / "RocketMax_new.dll").string() << "'\n";
+    scriptFile << "$backupPath = '" << (pluginsFolder / "RocketMax_backup.dll").string() << "'\n\n";
+
+    scriptFile << "Write-Host 'RocketMax Update Script' -ForegroundColor Cyan\n";
+    scriptFile << "Write-Host '========================' -ForegroundColor Cyan\n";
+    scriptFile << "Write-Host ''\n\n";
+
+    scriptFile << "try {\n";
+    scriptFile << "    Write-Host 'Downloading new version...' -ForegroundColor Yellow\n";
+    scriptFile << "    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12\n";
+    scriptFile << "    Invoke-WebRequest -Uri $downloadUrl -OutFile $tempPath -UseBasicParsing\n\n";
+
+    scriptFile << "    # Verify download - DLL should be at least 100KB\n";
+    scriptFile << "    $fileSize = (Get-Item $tempPath).Length\n";
+    scriptFile << "    if ($fileSize -lt 102400) {\n";
+    scriptFile << "        throw \"Downloaded file is too small ($fileSize bytes). Download may be corrupted.\"\n";
+    scriptFile << "    }\n";
+    scriptFile << "    Write-Host \"Downloaded successfully ($fileSize bytes)\" -ForegroundColor Green\n\n";
+
+    scriptFile << "    # Backup current version\n";
+    scriptFile << "    if (Test-Path $pluginPath) {\n";
+    scriptFile << "        Write-Host 'Backing up current version...' -ForegroundColor Yellow\n";
+    scriptFile << "        Copy-Item $pluginPath $backupPath -Force\n";
+    scriptFile << "    }\n\n";
+
+    scriptFile << "    # Replace plugin\n";
+    scriptFile << "    Write-Host 'Installing new version...' -ForegroundColor Yellow\n";
+    scriptFile << "    Move-Item $tempPath $pluginPath -Force\n\n";
+
+    scriptFile << "    Write-Host ''\n";
+    scriptFile << "    Write-Host 'Update complete!' -ForegroundColor Green\n";
+    scriptFile << "    Write-Host 'Please restart Rocket League to use the new version.' -ForegroundColor Cyan\n";
+    scriptFile << "    Write-Host ''\n";
+    scriptFile << "}\n";
+    scriptFile << "catch {\n";
+    scriptFile << "    Write-Host \"Error: $_\" -ForegroundColor Red\n";
+    scriptFile << "    if (Test-Path $backupPath) {\n";
+    scriptFile << "        Write-Host 'Restoring backup...' -ForegroundColor Yellow\n";
+    scriptFile << "        Move-Item $backupPath $pluginPath -Force\n";
+    scriptFile << "    }\n";
+    scriptFile << "    if (Test-Path $tempPath) { Remove-Item $tempPath -Force }\n";
+    scriptFile << "    exit 1\n";
+    scriptFile << "}\n";
+    scriptFile << "finally {\n";
+    scriptFile << "    # Clean up backup after successful install\n";
+    scriptFile << "    if (Test-Path $backupPath) { Remove-Item $backupPath -Force }\n";
+    scriptFile << "}\n\n";
+
+    scriptFile << "Write-Host 'Press any key to close...'\n";
+    scriptFile << "$null = $Host.UI.RawUI.ReadKey('NoEcho,IncludeKeyDown')\n";
+
+    scriptFile.close();
+    LOG("[RocketMax] [Update] Created update script: " + scriptPath.string());
+
+    // Launch the PowerShell script
+    std::string command = "powershell.exe -ExecutionPolicy Bypass -File \"" + scriptPath.string() + "\"";
+    LOG("[RocketMax] [Update] Launching: " + command);
+
+    // Use ShellExecute to run the script (shows a window so user can see progress)
+    HINSTANCE result = ShellExecuteA(NULL, "open", "powershell.exe",
+        ("-ExecutionPolicy Bypass -File \"" + scriptPath.string() + "\"").c_str(),
+        NULL, SW_SHOW);
+
+    if ((intptr_t)result <= 32) {
+        update_error = "Impossible de lancer le script (erreur " + std::to_string((intptr_t)result) + ")";
+        LOG("[RocketMax] [Update] Failed to launch script: " + std::to_string((intptr_t)result));
+        return;
+    }
+
+    update_ready.store(true);
+    update_available.store(false);
 
     gameWrapper->Execute([this](GameWrapper* gw) {
-        if (*cvar_enable_toasts) {
-            gw->Toast("RocketMax Update", "Telechargement en cours...", "default", 3.0f, ToastType_Info);
-        }
-    });
-
-    CurlRequest req;
-    req.url = update_download_url;
-    req.body = "";
-
-    HttpWrapper::SendCurlJsonRequest(req, [this](int code, std::string result)
-    {
-        update_downloading = false;
-
-        if (code != 200) {
-            update_error = "Echec du telechargement (code " + std::to_string(code) + ")";
-            LOG("[RocketMax] [Update] Download failed. HTTP code: " + std::to_string(code));
-
-            gameWrapper->Execute([this](GameWrapper* gw) {
-                gw->Toast("RocketMax Update", update_error, "default", 5.0f, ToastType_Error);
-            });
-            return;
-        }
-
-        // Save the downloaded file
-        std::string updatePath = getUpdateFilePath();
-        std::ofstream outFile(updatePath, std::ios::binary);
-        if (!outFile.is_open()) {
-            update_error = "Impossible d'ecrire le fichier";
-            LOG("[RocketMax] [Update] Could not open file for writing: " + updatePath);
-            return;
-        }
-
-        outFile.write(result.c_str(), result.size());
-        outFile.close();
-
-        LOG("[RocketMax] [Update] Downloaded update to: " + updatePath);
-        LOG("[RocketMax] [Update] File size: " + std::to_string(result.size()) + " bytes");
-
-        // Create a batch script to apply the update on next launch
-        std::string pluginPath = getPluginPath();
-        std::string batchPath = gameWrapper->GetDataFolder().string() + "/apply_update.bat";
-
-        std::ofstream batchFile(batchPath);
-        if (batchFile.is_open()) {
-            batchFile << "@echo off\n";
-            batchFile << "echo Applying RocketMax update...\n";
-            batchFile << "timeout /t 2 /nobreak > nul\n";
-            batchFile << "copy /Y \"" << updatePath << "\" \"" << pluginPath << "\"\n";
-            batchFile << "del \"" << updatePath << "\"\n";
-            batchFile << "del \"%~f0\"\n";
-            batchFile.close();
-            LOG("[RocketMax] [Update] Created update script: " + batchPath);
-        }
-
-        update_ready = true;
-        update_available = false;
-
-        gameWrapper->Execute([this](GameWrapper* gw) {
-            gw->Toast("RocketMax Update", "Mise a jour prete! Redemarrez Rocket League.", "default", 10.0f, ToastType_OK);
-        });
+        gw->Toast("RocketMax Update", "Script de mise a jour lance!", "default", 5.0f, ToastType_OK);
     });
 }
 

--- a/RocketMax/RocketMax.cpp
+++ b/RocketMax/RocketMax.cpp
@@ -70,8 +70,17 @@ void RocketMax::onLoad()
     cvarManager->registerCvar("rocketmax_server_url", API_ENDPOINT, "Server URL for data sync")
         .bindTo(cvar_server_url);
 
+    cvar_enable_auto_update = std::make_shared<bool>(true);
+    cvarManager->registerCvar("rocketmax_enable_auto_update", "1", "Enable automatic update checking")
+        .bindTo(cvar_enable_auto_update);
+
     // Process any offline queue from previous sessions
     processOfflineQueue();
+
+    // Check for updates if enabled
+    if (*cvar_enable_auto_update) {
+        checkForUpdates();
+    }
 
     bool erreur = initAPI();
     if (!erreur) {
@@ -609,6 +618,227 @@ void RocketMax::processOfflineQueue()
     // Note: In a real implementation, you'd parse the JSON and retry each request
     // For now, we just log that we found pending items
     LOG("[RocketMax] [OfflineQueue] Found pending items - will retry on next connection");
+}
+
+// ============ AUTO-UPDATE ============
+
+std::string RocketMax::getPluginPath()
+{
+    // Get the plugins folder path from BakkesMod
+    std::string dataFolder = gameWrapper->GetDataFolder().string();
+    // Navigate from data folder to plugins folder
+    // Data folder is typically: %APPDATA%/bakkesmod/bakkesmod/data
+    // Plugins folder is: %APPDATA%/bakkesmod/bakkesmod/plugins
+    size_t pos = dataFolder.rfind("data");
+    if (pos != std::string::npos) {
+        return dataFolder.substr(0, pos) + "plugins/RocketMax.dll";
+    }
+    return "";
+}
+
+std::string RocketMax::getUpdateFilePath()
+{
+    return gameWrapper->GetDataFolder().string() + "/RocketMax_update.dll";
+}
+
+bool RocketMax::parseVersionString(const std::string& version, int& major, int& minor, int& patch)
+{
+    // Parse version string like "v1.2.3" or "1.2.3"
+    std::string ver = version;
+    if (!ver.empty() && (ver[0] == 'v' || ver[0] == 'V')) {
+        ver = ver.substr(1);
+    }
+
+    int parsed = sscanf(ver.c_str(), "%d.%d.%d", &major, &minor, &patch);
+    return parsed >= 3;
+}
+
+bool RocketMax::isNewerVersion(const std::string& remoteVersion)
+{
+    int remoteMajor = 0, remoteMinor = 0, remotePatch = 0;
+    if (!parseVersionString(remoteVersion, remoteMajor, remoteMinor, remotePatch)) {
+        LOG("[RocketMax] [Update] Failed to parse remote version: " + remoteVersion);
+        return false;
+    }
+
+    LOG("[RocketMax] [Update] Comparing versions - Local: " +
+        std::to_string(VERSION_MAJOR) + "." + std::to_string(VERSION_MINOR) + "." + std::to_string(VERSION_PATCH) +
+        " vs Remote: " + std::to_string(remoteMajor) + "." + std::to_string(remoteMinor) + "." + std::to_string(remotePatch));
+
+    if (remoteMajor > VERSION_MAJOR) return true;
+    if (remoteMajor < VERSION_MAJOR) return false;
+    if (remoteMinor > VERSION_MINOR) return true;
+    if (remoteMinor < VERSION_MINOR) return false;
+    if (remotePatch > VERSION_PATCH) return true;
+    return false;
+}
+
+void RocketMax::checkForUpdates()
+{
+    if (update_checking) {
+        LOG("[RocketMax] [Update] Already checking for updates...");
+        return;
+    }
+
+    update_checking = true;
+    update_error = "";
+    LOG("[RocketMax] [Update] Checking for updates...");
+
+    CurlRequest req;
+    req.url = GITHUB_API_RELEASES;
+    // Use empty body for GET request - SendCurlJsonRequest handles JSON response
+    req.body = "";
+
+    HttpWrapper::SendCurlJsonRequest(req, [this](int code, std::string result)
+    {
+        update_checking = false;
+
+        if (code != 200) {
+            LOG("[RocketMax] [Update] Failed to check for updates. HTTP code: " + std::to_string(code));
+            update_error = "Erreur de connexion (code " + std::to_string(code) + ")";
+            return;
+        }
+
+        LOG("[RocketMax] [Update] Received response from GitHub API");
+
+        // Simple JSON parsing for tag_name and browser_download_url
+        // Looking for: "tag_name": "v1.2.3"
+        std::string tagKey = "\"tag_name\"";
+        size_t tagPos = result.find(tagKey);
+        if (tagPos == std::string::npos) {
+            LOG("[RocketMax] [Update] Could not find tag_name in response");
+            update_error = "Format de reponse invalide";
+            return;
+        }
+
+        // Find the value after tag_name
+        size_t colonPos = result.find(":", tagPos);
+        size_t quoteStart = result.find("\"", colonPos + 1);
+        size_t quoteEnd = result.find("\"", quoteStart + 1);
+        if (quoteStart == std::string::npos || quoteEnd == std::string::npos) {
+            update_error = "Erreur de parsing version";
+            return;
+        }
+
+        latest_version = result.substr(quoteStart + 1, quoteEnd - quoteStart - 1);
+        LOG("[RocketMax] [Update] Latest version: " + latest_version);
+
+        // Find download URL for RocketMax.dll
+        std::string dllName = "RocketMax.dll";
+        size_t dllPos = result.find(dllName);
+        if (dllPos != std::string::npos) {
+            // Look backwards for browser_download_url
+            std::string urlKey = "\"browser_download_url\"";
+            size_t urlKeyPos = result.rfind(urlKey, dllPos);
+            if (urlKeyPos != std::string::npos) {
+                size_t urlColonPos = result.find(":", urlKeyPos + urlKey.length());
+                size_t urlQuoteStart = result.find("\"", urlColonPos + 1);
+                size_t urlQuoteEnd = result.find("\"", urlQuoteStart + 1);
+                if (urlQuoteStart != std::string::npos && urlQuoteEnd != std::string::npos) {
+                    update_download_url = result.substr(urlQuoteStart + 1, urlQuoteEnd - urlQuoteStart - 1);
+                    LOG("[RocketMax] [Update] Download URL: " + update_download_url);
+                }
+            }
+        }
+
+        // Check if this is a newer version
+        if (isNewerVersion(latest_version)) {
+            update_available = true;
+            LOG("[RocketMax] [Update] New version available: " + latest_version);
+
+            gameWrapper->Execute([this](GameWrapper* gw) {
+                if (*cvar_enable_toasts) {
+                    std::string msg = "Nouvelle version disponible: " + latest_version;
+                    gw->Toast("RocketMax Update", msg, "default", 8.0f, ToastType_Info);
+                }
+            });
+        }
+        else {
+            update_available = false;
+            LOG("[RocketMax] [Update] Already on latest version");
+        }
+    });
+}
+
+void RocketMax::downloadUpdate()
+{
+    if (update_download_url.empty()) {
+        update_error = "URL de telechargement non disponible";
+        LOG("[RocketMax] [Update] No download URL available");
+        return;
+    }
+
+    if (update_downloading) {
+        LOG("[RocketMax] [Update] Already downloading...");
+        return;
+    }
+
+    update_downloading = true;
+    update_error = "";
+    LOG("[RocketMax] [Update] Starting download from: " + update_download_url);
+
+    gameWrapper->Execute([this](GameWrapper* gw) {
+        if (*cvar_enable_toasts) {
+            gw->Toast("RocketMax Update", "Telechargement en cours...", "default", 3.0f, ToastType_Info);
+        }
+    });
+
+    CurlRequest req;
+    req.url = update_download_url;
+    req.body = "";
+
+    HttpWrapper::SendCurlJsonRequest(req, [this](int code, std::string result)
+    {
+        update_downloading = false;
+
+        if (code != 200) {
+            update_error = "Echec du telechargement (code " + std::to_string(code) + ")";
+            LOG("[RocketMax] [Update] Download failed. HTTP code: " + std::to_string(code));
+
+            gameWrapper->Execute([this](GameWrapper* gw) {
+                gw->Toast("RocketMax Update", update_error, "default", 5.0f, ToastType_Error);
+            });
+            return;
+        }
+
+        // Save the downloaded file
+        std::string updatePath = getUpdateFilePath();
+        std::ofstream outFile(updatePath, std::ios::binary);
+        if (!outFile.is_open()) {
+            update_error = "Impossible d'ecrire le fichier";
+            LOG("[RocketMax] [Update] Could not open file for writing: " + updatePath);
+            return;
+        }
+
+        outFile.write(result.c_str(), result.size());
+        outFile.close();
+
+        LOG("[RocketMax] [Update] Downloaded update to: " + updatePath);
+        LOG("[RocketMax] [Update] File size: " + std::to_string(result.size()) + " bytes");
+
+        // Create a batch script to apply the update on next launch
+        std::string pluginPath = getPluginPath();
+        std::string batchPath = gameWrapper->GetDataFolder().string() + "/apply_update.bat";
+
+        std::ofstream batchFile(batchPath);
+        if (batchFile.is_open()) {
+            batchFile << "@echo off\n";
+            batchFile << "echo Applying RocketMax update...\n";
+            batchFile << "timeout /t 2 /nobreak > nul\n";
+            batchFile << "copy /Y \"" << updatePath << "\" \"" << pluginPath << "\"\n";
+            batchFile << "del \"" << updatePath << "\"\n";
+            batchFile << "del \"%~f0\"\n";
+            batchFile.close();
+            LOG("[RocketMax] [Update] Created update script: " + batchPath);
+        }
+
+        update_ready = true;
+        update_available = false;
+
+        gameWrapper->Execute([this](GameWrapper* gw) {
+            gw->Toast("RocketMax Update", "Mise a jour prete! Redemarrez Rocket League.", "default", 10.0f, ToastType_OK);
+        });
+    });
 }
 
 // ============ OVERLAY WINDOW ============

--- a/RocketMax/RocketMax.h
+++ b/RocketMax/RocketMax.h
@@ -46,11 +46,22 @@ class RocketMax: public BakkesMod::Plugin::BakkesModPlugin
 	void processOfflineQueue();
 	std::string getQueueFilePath();
 
+	// Auto-update
+	void checkForUpdates();
+	void downloadUpdate();
+	bool parseVersionString(const std::string& version, int& major, int& minor, int& patch);
+	bool isNewerVersion(const std::string& remoteVersion);
+	std::string getPluginPath();
+	std::string getUpdateFilePath();
+
 
 
 	// vars
 	//#define API_ENDPOINT "http://localhost:8080"
 	#define API_ENDPOINT "http://localhost:8080"
+	#define GITHUB_API_RELEASES "https://api.github.com/repos/tellebma/RocketMax-Plugin/releases/latest"
+	#define GITHUB_REPO_OWNER "tellebma"
+	#define GITHUB_REPO_NAME "RocketMax-Plugin"
 
 	// Vars used by prgm
 	bool pluginLoaded = false;
@@ -92,7 +103,17 @@ class RocketMax: public BakkesMod::Plugin::BakkesModPlugin
 	std::shared_ptr<bool> cvar_enable_toasts;
 	std::shared_ptr<bool> cvar_enable_overlay;
 	std::shared_ptr<bool> cvar_enable_streak_alerts;
+	std::shared_ptr<bool> cvar_enable_auto_update;
 	std::shared_ptr<std::string> cvar_server_url;
+
+	// Auto-update state
+	bool update_available = false;
+	bool update_checking = false;
+	bool update_downloading = false;
+	bool update_ready = false;
+	std::string latest_version = "";
+	std::string update_download_url = "";
+	std::string update_error = "";
 
 	// Overlay state
 	bool overlay_visible = true;

--- a/RocketMax/RocketMax.h
+++ b/RocketMax/RocketMax.h
@@ -6,6 +6,8 @@
 #include "bakkesmod/plugin/PluginSettingsWindow.h"
 
 #include "version.h"
+#include <atomic>
+#include <filesystem>
 
 constexpr auto plugin_version = stringify(VERSION_MAJOR) "." stringify(VERSION_MINOR) "." stringify(VERSION_PATCH) "." stringify(VERSION_BUILD);
 
@@ -48,20 +50,17 @@ class RocketMax: public BakkesMod::Plugin::BakkesModPlugin
 
 	// Auto-update
 	void checkForUpdates();
-	void downloadUpdate();
+	void launchUpdateScript();
 	bool parseVersionString(const std::string& version, int& major, int& minor, int& patch);
 	bool isNewerVersion(const std::string& remoteVersion);
-	std::string getPluginPath();
-	std::string getUpdateFilePath();
-
-
+	std::filesystem::path getPluginsFolder();
+	std::filesystem::path getUpdateScriptPath();
+	std::string extractJsonValue(const std::string& json, const std::string& key);
 
 	// vars
 	//#define API_ENDPOINT "http://localhost:8080"
 	#define API_ENDPOINT "http://localhost:8080"
 	#define GITHUB_API_RELEASES "https://api.github.com/repos/tellebma/RocketMax-Plugin/releases/latest"
-	#define GITHUB_REPO_OWNER "tellebma"
-	#define GITHUB_REPO_NAME "RocketMax-Plugin"
 
 	// Vars used by prgm
 	bool pluginLoaded = false;
@@ -106,11 +105,10 @@ class RocketMax: public BakkesMod::Plugin::BakkesModPlugin
 	std::shared_ptr<bool> cvar_enable_auto_update;
 	std::shared_ptr<std::string> cvar_server_url;
 
-	// Auto-update state
-	bool update_available = false;
-	bool update_checking = false;
-	bool update_downloading = false;
-	bool update_ready = false;
+	// Auto-update state (atomic for thread safety with async callbacks)
+	std::atomic<bool> update_available{false};
+	std::atomic<bool> update_checking{false};
+	std::atomic<bool> update_ready{false};
 	std::string latest_version = "";
 	std::string update_download_url = "";
 	std::string update_error = "";

--- a/RocketMax/RocketMaxSettings.cpp
+++ b/RocketMax/RocketMaxSettings.cpp
@@ -72,29 +72,27 @@ void RocketMax::RenderSettings() {
     ImGui::TextUnformatted("Mises a jour");
     ImGui::Spacing();
 
-    if (update_checking) {
+    if (update_checking.load()) {
         ImGui::TextColored(ImVec4(1.0f, 1.0f, 0.0f, 1.0f), "Verification en cours...");
     }
-    else if (update_ready) {
-        ImGui::TextColored(ImVec4(0.0f, 1.0f, 0.0f, 1.0f), "Mise a jour prete !");
-        ImGui::TextUnformatted("Redemarrez Rocket League pour appliquer la mise a jour.");
+    else if (update_ready.load()) {
+        ImGui::TextColored(ImVec4(0.0f, 1.0f, 0.0f, 1.0f), "Mise a jour en cours !");
+        ImGui::TextUnformatted("Le script de mise a jour a ete lance.");
+        ImGui::TextUnformatted("Redemarrez Rocket League une fois termine.");
         ImGui::Spacing();
         ImGui::TextUnformatted(("Nouvelle version: " + latest_version).c_str());
     }
-    else if (update_available) {
+    else if (update_available.load()) {
         ImGui::TextColored(ImVec4(1.0f, 0.8f, 0.0f, 1.0f), "Nouvelle version disponible !");
         ImGui::TextUnformatted(("Version actuelle: " + std::string(plugin_version)).c_str());
         ImGui::TextUnformatted(("Nouvelle version: " + latest_version).c_str());
         ImGui::Spacing();
 
-        if (update_downloading) {
-            ImGui::TextColored(ImVec4(1.0f, 1.0f, 0.0f, 1.0f), "Telechargement en cours...");
+        if (ImGui::Button("Installer la mise a jour")) {
+            launchUpdateScript();
         }
-        else {
-            if (ImGui::Button("Telecharger la mise a jour")) {
-                downloadUpdate();
-            }
-        }
+        ImGui::SameLine();
+        ImGui::TextColored(ImVec4(0.6f, 0.6f, 0.6f, 1.0f), "(lance un script PowerShell)");
     }
     else {
         ImGui::TextColored(ImVec4(0.5f, 0.5f, 0.5f, 1.0f), "Vous avez la derniere version");

--- a/RocketMax/RocketMaxSettings.cpp
+++ b/RocketMax/RocketMaxSettings.cpp
@@ -50,10 +50,64 @@ void RocketMax::RenderSettings() {
         }
     }
 
+    // Auto-update toggle
+    CVarWrapper autoUpdateCvar = cvarManager->getCvar("rocketmax_enable_auto_update");
+    if (autoUpdateCvar) {
+        bool autoUpdateEnabled = autoUpdateCvar.getBoolValue();
+        if (ImGui::Checkbox("Verifier les mises a jour automatiquement", &autoUpdateEnabled)) {
+            autoUpdateCvar.setValue(autoUpdateEnabled);
+        }
+    }
+
     ImGui::Spacing();
 
     // Server URL (read-only display)
     ImGui::TextUnformatted(("Serveur: " + std::string(API_ENDPOINT)).c_str());
+
+    ImGui::Spacing();
+    ImGui::Separator();
+    ImGui::Spacing();
+
+    // Update Section
+    ImGui::TextUnformatted("Mises a jour");
+    ImGui::Spacing();
+
+    if (update_checking) {
+        ImGui::TextColored(ImVec4(1.0f, 1.0f, 0.0f, 1.0f), "Verification en cours...");
+    }
+    else if (update_ready) {
+        ImGui::TextColored(ImVec4(0.0f, 1.0f, 0.0f, 1.0f), "Mise a jour prete !");
+        ImGui::TextUnformatted("Redemarrez Rocket League pour appliquer la mise a jour.");
+        ImGui::Spacing();
+        ImGui::TextUnformatted(("Nouvelle version: " + latest_version).c_str());
+    }
+    else if (update_available) {
+        ImGui::TextColored(ImVec4(1.0f, 0.8f, 0.0f, 1.0f), "Nouvelle version disponible !");
+        ImGui::TextUnformatted(("Version actuelle: " + std::string(plugin_version)).c_str());
+        ImGui::TextUnformatted(("Nouvelle version: " + latest_version).c_str());
+        ImGui::Spacing();
+
+        if (update_downloading) {
+            ImGui::TextColored(ImVec4(1.0f, 1.0f, 0.0f, 1.0f), "Telechargement en cours...");
+        }
+        else {
+            if (ImGui::Button("Telecharger la mise a jour")) {
+                downloadUpdate();
+            }
+        }
+    }
+    else {
+        ImGui::TextColored(ImVec4(0.5f, 0.5f, 0.5f, 1.0f), "Vous avez la derniere version");
+        ImGui::Spacing();
+        if (ImGui::Button("Verifier les mises a jour")) {
+            checkForUpdates();
+        }
+    }
+
+    if (!update_error.empty()) {
+        ImGui::Spacing();
+        ImGui::TextColored(ImVec4(1.0f, 0.0f, 0.0f, 1.0f), ("Erreur: " + update_error).c_str());
+    }
 
     ImGui::Spacing();
     ImGui::Separator();

--- a/RocketMax/pch.h
+++ b/RocketMax/pch.h
@@ -2,6 +2,8 @@
 
 #define WIN32_LEAN_AND_MEAN
 #define _CRT_SECURE_NO_WARNINGS
+#include <windows.h>
+#include <shellapi.h>
 #include "bakkesmod/plugin/bakkesmodplugin.h"
 
 #include <string>


### PR DESCRIPTION
- Check for new versions via GitHub Releases API on plugin load
- Compare semantic versions (MAJOR.MINOR.PATCH)
- Show toast notification when update is available
- Add update section in Settings UI with download button
- Download new DLL and prepare batch script for next launch
- Add CVar to enable/disable auto-update checking