### PR TITLE
fix: Remove existing temp file before downloading update

### DIFF
--- a/RocketMax/RocketMax.cpp
+++ b/RocketMax/RocketMax.cpp
@@ -830,6 +830,8 @@ void RocketMax::launchUpdateScript()
     scriptFile << "Write-Host ''\n\n";
 
     scriptFile << "try {\n";
+    scriptFile << "    # Remove temp file if it exists from a previous attempt\n";
+    scriptFile << "    if (Test-Path $tempPath) { Remove-Item $tempPath -Force }\n\n";
     scriptFile << "    Write-Host 'Downloading new version...' -ForegroundColor Yellow\n";
     scriptFile << "    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12\n";
     scriptFile << "    Invoke-WebRequest -Uri $downloadUrl -OutFile $tempPath -UseBasicParsing\n\n";


### PR DESCRIPTION
The auto-update script was failing with "Impossible de créer un fichier déjà existant" when the temp file RocketMax_new.dll already existed from a previous failed download attempt. Now the script removes the temp file if it exists before attempting to download.