### PR TITLE
fix: Correct regex pattern for semantic-release version detection

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,8 +47,8 @@ jobs:
           OUTPUT=$(npx semantic-release --dry-run 2>&1) || true
           echo "$OUTPUT"
 
-          # Look for "next release version is X.X.X"
-          VERSION=$(echo "$OUTPUT" | grep -oP 'next release version is \K[0-9]+\.[0-9]+\.[0-9]+' || echo "")
+          # Look for "The next release version is X.X.X" (case insensitive)
+          VERSION=$(echo "$OUTPUT" | grep -oiP 'The next release version is \K[0-9]+\.[0-9]+\.[0-9]+' || echo "")
           if [ -n "$VERSION" ]; then
             echo "version=$VERSION" >> $GITHUB_OUTPUT
             echo "should_release=true" >> $GITHUB_OUTPUT


### PR DESCRIPTION
The regex was looking for "next release version is X.X.X" but semantic-release outputs "The next release version is X.X.X". Added the missing "The" prefix and made it case-insensitive.