### PR TITLE
fix: Add write permissions to determine-version job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,9 @@ jobs:
       version: ${{ steps.get-version.outputs.version }}
       should_release: ${{ steps.get-version.outputs.should_release }}
 
+    permissions:
+      contents: write
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
semantic-release dry-run requires contents:write permission to verify it can push tags, even though it doesn't actually push in dry-run mode.